### PR TITLE
Show route information at bottom of timetable

### DIFF
--- a/src/MakeViewModel.elm
+++ b/src/MakeViewModel.elm
@@ -123,6 +123,13 @@ viewTrip :
     -> ViewModel.Trip
 viewTrip stopDict maybeTrip schedules =
     { name = Maybe.map .name maybeTrip
+    , route =
+        case Maybe.map .routeId maybeTrip of
+            Just (Mbta.RouteId route) ->
+                Just route
+
+            Nothing ->
+                Nothing
     , bikes =
         case maybeTrip of
             Just trip ->

--- a/src/MakeViewModel.elm
+++ b/src/MakeViewModel.elm
@@ -123,13 +123,7 @@ viewTrip :
     -> ViewModel.Trip
 viewTrip stopDict maybeTrip schedules =
     { name = Maybe.map .name maybeTrip
-    , route =
-        case Maybe.map .routeId maybeTrip of
-            Just (Mbta.RouteId route) ->
-                Just route
-
-            Nothing ->
-                Nothing
+    , route = Maybe.map .routeId maybeTrip
     , bikes =
         case maybeTrip of
             Just trip ->

--- a/src/View.elm
+++ b/src/View.elm
@@ -2,6 +2,7 @@ module View exposing (view)
 
 import Browser
 import Element as El exposing (Element)
+import Element.Font as Font
 import Model exposing (Msg)
 import ViewModel
 
@@ -66,7 +67,7 @@ type alias Schedule =
 viewTimetable : ViewModel.Timetable -> Element msg
 viewTimetable timetable =
     El.row
-        [ El.spacing 15 ]
+        [ El.spacing 15, El.padding 10 ]
         (viewStopHeaders timetable.stopHeaders :: List.map viewTripColumn timetable.trips)
 
 
@@ -77,6 +78,7 @@ viewStopHeaders stopHeaders =
         (List.concat
             [ [ El.text "" ]
             , List.map viewStopHeaderCell stopHeaders
+            , [ El.text "" ]
             ]
         )
 
@@ -98,10 +100,11 @@ viewTripColumn : ViewModel.Trip -> Element msg
 viewTripColumn trip =
     El.column
         []
-        (tripDescriptor trip
-            :: List.map
-                viewSchedule
-                trip.schedules
+        (List.concat
+            [ [ tripDescriptor trip ]
+            , List.map viewSchedule trip.schedules
+            , [ tripFooter trip ]
+            ]
         )
 
 
@@ -129,3 +132,25 @@ tripDescriptor trip =
           else
             El.text " "
         ]
+
+
+tripFooter : ViewModel.Trip -> Element msg
+tripFooter trip =
+    (case trip.route of
+        Just "CR-Middleborough" ->
+            "MID"
+
+        Just "CR-Kingston" ->
+            "KIN"
+
+        Just "CR-Greenbush" ->
+            "GRN"
+
+        Just _ ->
+            ""
+
+        Nothing ->
+            ""
+    )
+        |> El.text
+        |> El.el [ Font.variant Font.smallCaps ]

--- a/src/View.elm
+++ b/src/View.elm
@@ -3,6 +3,7 @@ module View exposing (view)
 import Browser
 import Element as El exposing (Element)
 import Element.Font as Font
+import Mbta
 import Model exposing (Msg)
 import ViewModel
 
@@ -137,13 +138,13 @@ tripDescriptor trip =
 tripFooter : ViewModel.Trip -> Element msg
 tripFooter trip =
     (case trip.route of
-        Just "CR-Middleborough" ->
+        Just (Mbta.RouteId "CR-Middleborough") ->
             "MID"
 
-        Just "CR-Kingston" ->
+        Just (Mbta.RouteId "CR-Kingston") ->
             "KIN"
 
-        Just "CR-Greenbush" ->
+        Just (Mbta.RouteId "CR-Greenbush") ->
             "GRN"
 
         Just _ ->

--- a/src/ViewModel.elm
+++ b/src/ViewModel.elm
@@ -27,6 +27,7 @@ type alias StopHeader =
 
 type alias Trip =
     { name : Maybe String
+    , route : Maybe String
     , bikes : Bool
     , schedules : List Schedule
     }

--- a/src/ViewModel.elm
+++ b/src/ViewModel.elm
@@ -1,5 +1,7 @@
 module ViewModel exposing (Schedule, StopHeader, Timetable, Timetables, Trip, ViewModel(..))
 
+import Mbta
+
 
 type ViewModel
     = Loading
@@ -27,7 +29,7 @@ type alias StopHeader =
 
 type alias Trip =
     { name : Maybe String
-    , route : Maybe String
+    , route : Maybe Mbta.RouteId
     , bikes : Bool
     , schedules : List Schedule
     }


### PR DESCRIPTION
@skyqrose I was fiddling around a bit and added the ability to show which route a train is on at the bottom of the timetable. I did some abbreviating to easily fit the route information into the space provided, and set it to use the smallcaps variant of the font (which I think will look nice, but doesn't seem to make a difference with the default font sans-serif font for me).

Implements [this card](https://github.com/skyqrose/mbta-old-colony-timetable/projects/1#card-25811047), not sure how we want to track the association between cards and PRs.